### PR TITLE
Add 10 MB max buffer limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ const formatOutdatedPackages = (outdatedPackages = {}, packageNames = []) => {
 
 const execP = outdatedCommand => {
   return new Promise((resolve, reject) => {
-    exec(outdatedCommand, function(error, stdout, stderr) {
+    const execOptions = { maxBuffer: 10 * 1024 * 1024 };
+    exec(outdatedCommand, execOptions, function(error, stdout, stderr) {
       if (stdout) {
         resolve(JSON.parse(stdout));
       }


### PR DESCRIPTION
- In line with https://github.com/revathskumar/npm-audit-ci/pull/11
- Handles cases when json output from `npm outdated --json` is too large to parse

Ref: https://nodejs.org/api/child_process.html#child_process_maxbuffer_and_unicode