### PR TITLE
Added option for specific packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ import { schedule } from "danger";
 import npmOutdated from "danger-plugin-npm-outdated";
 
 // Note: You need to use schedule()
-schedule(npmOutdated());
+schedule(npmOutdated({
+  packages: ['@babel/cli'], // (OPTIONAL) Specify which packages you want to target
+}));
 ```
 
 ## Sample message

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ const execP = outdatedCommand => {
 };
 
 export default async function npmOutdated(options = {}) {
-  let outdatedCommand = "npm outdated --json";
+  const filterPackages = (options.packages || []).join(' ');
+  let outdatedCommand = `npm outdated ${filterPackages} --json`;
 
   try {
     const outdatedPackages = await execP(outdatedCommand);


### PR DESCRIPTION
Added additional options for filtering specific packages:

```
npmOutdated({
  packages: ['@babel/cli'],
});
```
This would *only* check for `@babel/cli` package instead.