### PR TITLE
Adding support for exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ import npmOutdated from "danger-plugin-npm-outdated";
 
 // Note: You need to use schedule()
 schedule(npmOutdated());
+
+// example using options
+schedule(npmOutdated({ exclude: ['package-name'] }));
 ```
+
+## Options
+| Option | Type | Default |
+| ------ | ---- | ------- |
+| `exclude` | `string[]` | `[]` |
+
 
 ## Sample message
 

--- a/index.js
+++ b/index.js
@@ -28,11 +28,16 @@ const execP = outdatedCommand => {
 };
 
 export default async function npmOutdated(options = {}) {
+  const exclude = (options && options.exclude) || [];
+  if (exclude && !Array.isArray(exclude)) {
+    throw new TypeError('exclude option must be of type string[] containing package names to exclude');
+  }
+
   let outdatedCommand = "npm outdated --json";
 
   try {
     const outdatedPackages = await execP(outdatedCommand);
-    const packageNames = Object.keys(outdatedPackages);
+    const packageNames = Object.keys(outdatedPackages).filter((packageName) => !exclude.includes(packageName));
     if (packageNames.length) {
       const packagesTable = formatOutdatedPackages(
         outdatedPackages,


### PR DESCRIPTION
* Added support for an exclude option to be able to explicitly exclude packages from the outdated list of packages.

This is really helpful if you have private repos and the versions can't be identified. For instance the output of something that **is** uptodate still looks like:
```
| package-name | 1.0.0 | git | git |
```

Example usage:
```
schedule(npmOutdated({ exclude: ['package-name'] }));
```