### PR TITLE
Add option to only consider prod dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ import npmOutdated from "danger-plugin-npm-outdated";
 schedule(npmOutdated());
 ```
 
+## Options
+
+|Name|Default|Function|
+|-|-|-|
+|prodOnly|false|Only consider production dependencies|
+
+Pass options to the `npmOutdated` function
+
+```ts
+scheduled(npmOutdated({ prodOnly: true }))
+```
+
 ## Sample message
 
 ![sample message](https://raw.githubusercontent.com/revathskumar/danger-plugin-npm-outdated/master/images/message.png)


### PR DESCRIPTION
This plugin is great, but I found myself missing the option to only consider production dependencies.

I've added this as an option, and if this option has not been provided, it should also indicate the kind of dependency in the output.

Please let me know if I've missed something or you have any objections